### PR TITLE
Refactor queries and schemas to build graph

### DIFF
--- a/dbs/neo4j/api/routers/wine.py
+++ b/dbs/neo4j/api/routers/wine.py
@@ -1,7 +1,11 @@
 from fastapi import APIRouter, HTTPException, Query, Request
 from neo4j import AsyncManagedTransaction
-from schemas.retriever import (FullTextSearch, MostWinesByVariety,
-                               TopWinesByCountry, TopWinesByProvince)
+from schemas.retriever import (
+    FullTextSearch,
+    MostWinesByVariety,
+    TopWinesByCountry,
+    TopWinesByProvince,
+)
 
 wine_router = APIRouter()
 

--- a/dbs/neo4j/api/routers/wine.py
+++ b/dbs/neo4j/api/routers/wine.py
@@ -1,12 +1,7 @@
 from fastapi import APIRouter, HTTPException, Query, Request
 from neo4j import AsyncManagedTransaction
-
-from schemas.retriever import (
-    FullTextSearch,
-    TopWinesByCountry,
-    TopWinesByProvince,
-    MostWinesByVariety,
-)
+from schemas.retriever import (FullTextSearch, MostWinesByVariety,
+                               TopWinesByCountry, TopWinesByProvince)
 
 wine_router = APIRouter()
 

--- a/dbs/neo4j/schemas/wine.py
+++ b/dbs/neo4j/schemas/wine.py
@@ -1,26 +1,6 @@
 from pydantic import BaseModel, root_validator
 
 
-class Location(BaseModel):
-    country: str | None
-    province: str | None
-    region_1: str | None
-    region_2: str | None
-
-    @root_validator
-    def _fill_country_unknowns(cls, values):
-        "Fill in missing country values with 'Unknown'"
-        country = values.get("country")
-        if not country:
-            values["country"] = "Unknown"
-        return values
-
-
-class Taster(BaseModel):
-    taster_name: str | None
-    taster_twitter_handle: str | None
-
-
 class Wine(BaseModel):
     id: int
     points: int
@@ -68,19 +48,9 @@ class Wine(BaseModel):
         return values
 
     @root_validator
-    def _add_location_dict(cls, values):
-        "Convert location attributes to a nested dict"
-        location = Location(**values).dict()
-        values["location"] = location
-        for key in location.keys():
-            values.pop(key)
-        return values
-
-    @root_validator
-    def _add_taster_dict(cls, values):
-        "Convert taster attributes to a nested dict"
-        taster = Taster(**values).dict()
-        values["taster"] = taster
-        for key in taster.keys():
-            values.pop(key)
+    def _fill_country_unknowns(cls, values):
+        "Fill in missing country values with 'Unknown', as we always want this field to be queryable"
+        country = values.get("country")
+        if not country:
+            values["country"] = "Unknown"
         return values


### PR DESCRIPTION
## Refactor

* There's no need to complicate things by converting the existing data to a nested dict (keeping the original dict from the raw data makes sense from a build query perspective)
* Running each portion (nodes first and then edges after) is also unnecessary -- a single build query with `WITH` and `MERGE` statements does the job