### PR TITLE
Neo4j updates

### DIFF
--- a/dbs/neo4j/.env.example
+++ b/dbs/neo4j/.env.example
@@ -3,5 +3,8 @@ NEO4J_PASSWORD = ""
 NEO4J_VERSION = 5.6.0
 DB_SERVICE = "db"
 
+# Container image tag
+TAG = "0.2.0"
+
 # Docker project namespace (defaults to the current folder name if not set)
 COMPOSE_PROJECT_NAME = neo4j_wine

--- a/dbs/neo4j/README.md
+++ b/dbs/neo4j/README.md
@@ -84,31 +84,34 @@ This cURL request passes the search terms "**tuscany red**" to the `/wine/search
 ```json
 [
     {
-        "wineID": 22170,
-        "country": "Italy",
-        "title": "Kirkland Signature 2004 Tuscany Red (Toscana)",
-        "points": 87,
-        "price": 20.0,
-        "variety": "Red Blend",
-        "winery": "Kirkland Signature"
-    },
-    {
         "wineID": 66393,
         "country": "Italy",
         "title": "Capezzana 1999 Ghiaie Della Furba Red (Tuscany)",
+        "description": "Very much a baby, this is one big, bold, burly Cab-Merlot-Syrah blend that's filled to the brim with extracted plum fruit, bitter chocolate and earth. It takes a long time in the glass for it to lose its youthful, funky aromatics, and on the palate things are still a bit scattered. But in due time things will settle and integrate",
         "points": 90,
-        "price": 49.0,
+        "price": 49,
         "variety": "Red Blend",
         "winery": "Capezzana"
     },
     {
-        "wineID": 35880,
+        "wineID": 40960,
         "country": "Italy",
-        "title": "Torrenera 2006 Red (Toscana)",
-        "points": 87,
-        "price": "Not available",
+        "title": "Fattoria di Grignano 2011 Pietramaggio Red (Toscana)",
+        "description": "Here's a simple but well made red from Tuscany that has floral aromas of violet and rose with berry notes. The palate offers bright cherry, red currant and a touch of spice. Pair this with pasta dishes or grilled vegetables.",
+        "points": 86,
+        "price": 11,
         "variety": "Red Blend",
-        "winery": "Torrenera"
+        "winery": "Fattoria di Grignano"
+    },
+    {
+        "wineID": 73595,
+        "country": "Italy",
+        "title": "I Giusti e Zanza 2011 Belcore Red (Toscana)",
+        "description": "With aromas of violet, tilled soil and red berries, this blend of Sangiovese and Merlot recalls sunny Tuscany. It's loaded with wild cherry flavors accented by white pepper, cinnamon and vanilla. The palate is uplifted by vibrant acidity and fine tannins.",
+        "points": 89,
+        "price": 27,
+        "variety": "Red Blend",
+        "winery": "I Giusti e Zanza"
     }
 ]
 ```

--- a/dbs/neo4j/README.md
+++ b/dbs/neo4j/README.md
@@ -76,7 +76,7 @@ Once the data has been successfully loaded into Neo4j and the containers are up 
 
 ```sh
 curl -X 'GET' \
-  'http://localhost:8000/wine/search?terms=tuscany%20red'
+  'http://localhost:8000/wine/search?terms=tuscany%20red&max_price=50'
 ```
 
 This cURL request passes the search terms "**tuscany red**" to the `/wine/search/` endpoint, which is then parsed into a working Cypher query by the FastAPI backend. The query runs and retrieves results from a full text search index (that looks for these keywords in the wine's title and description), and, if the setup was done correctly, we should see the following response:

--- a/dbs/neo4j/api/config.py
+++ b/dbs/neo4j/api/config.py
@@ -4,6 +4,7 @@ from pydantic import BaseSettings
 class Settings(BaseSettings):
     db_service: str
     neo4j_password: str
+    tag: str
 
     class Config:
         env_file = ".env"

--- a/dbs/neo4j/api/main.py
+++ b/dbs/neo4j/api/main.py
@@ -2,14 +2,12 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from functools import lru_cache
 
-from dotenv import load_dotenv
+
 from fastapi import FastAPI
 from neo4j import AsyncGraphDatabase
 
 from api.config import Settings
 from api.routers.wine import wine_router
-
-load_dotenv()
 
 
 @lru_cache()
@@ -38,7 +36,7 @@ app = FastAPI(
     description=(
         "Query from a Neo4j database of 130k wine reviews from the Wine Enthusiast magazine"
     ),
-    version="0.2.0",
+    version=get_settings().tag,
     lifespan=lifespan,
 )
 
@@ -52,9 +50,3 @@ async def root():
 
 # Attach routes
 app.include_router(wine_router, prefix="/wine", tags=["wine"])
-
-
-if __name__ == "__main__":
-    import uvicorn
-
-    uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)

--- a/dbs/neo4j/api/main.py
+++ b/dbs/neo4j/api/main.py
@@ -2,7 +2,6 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from functools import lru_cache
 
-
 from fastapi import FastAPI
 from neo4j import AsyncGraphDatabase
 

--- a/dbs/neo4j/api/routers/wine.py
+++ b/dbs/neo4j/api/routers/wine.py
@@ -124,11 +124,13 @@ async def _search_by_keywords(
             coalesce(wine.price, "Not available") AS price,
             wine.variety AS variety,
             wine.winery AS winery
-        ORDER BY points DESC, score DESC LIMIT 5
+        ORDER BY score DESC, points DESC LIMIT 5
     """
     response = await tx.run(query, terms=terms, price=price)
     result = await response.data()
-    return result
+    if result:
+        return [FullTextSearch(**r) for r in result]
+    return None
 
 
 async def _top_by_country(
@@ -151,7 +153,9 @@ async def _top_by_country(
     """
     response = await tx.run(query, country=country)
     result = await response.data()
-    return result
+    if result:
+        return [TopWinesByCountry(**r) for r in result]
+    return None
 
 
 async def _top_by_province(
@@ -175,7 +179,9 @@ async def _top_by_province(
     """
     response = await tx.run(query, province=province)
     result = await response.data()
-    return result
+    if result:
+        return [TopWinesByProvince(**r) for r in result]
+    return None
 
 
 async def _most_by_variety(
@@ -195,4 +201,6 @@ async def _most_by_variety(
     """
     response = await tx.run(query, variety=variety, points=points)
     result = await response.data()
-    return result
+    if result:
+        return [MostWinesByVariety(**r) for r in result]
+    return None

--- a/dbs/neo4j/schemas/retriever.py
+++ b/dbs/neo4j/schemas/retriever.py
@@ -30,6 +30,7 @@ class TopWinesByCountry(BaseModel):
     wineID: int
     country: str
     title: str
+    description: str | None
     points: int
     price: float | str
     variety: str | None
@@ -41,6 +42,7 @@ class TopWinesByProvince(BaseModel):
     country: str
     province: str
     title: str
+    description: str | None
     points: int
     price: float | str
     variety: str | None

--- a/dbs/neo4j/scripts/build_graph.py
+++ b/dbs/neo4j/scripts/build_graph.py
@@ -9,9 +9,8 @@ from pathlib import Path
 from typing import Any
 
 from dotenv import load_dotenv
-from pydantic.main import ModelMetaclass
-
 from neo4j import AsyncGraphDatabase, AsyncManagedTransaction, AsyncSession
+from pydantic.main import ModelMetaclass
 
 sys.path.insert(1, os.path.realpath(Path(__file__).resolve().parents[1]))
 from schemas.wine import Wine
@@ -126,9 +125,7 @@ async def build_query(tx: AsyncManagedTransaction, data: list[JsonBlob]) -> None
 
 
 async def main(files: list[str]) -> None:
-    async with AsyncGraphDatabase.driver(
-        URI, auth=(NEO4J_USER, NEO4J_PASSWORD)
-    ) as driver:
+    async with AsyncGraphDatabase.driver(URI, auth=(NEO4J_USER, NEO4J_PASSWORD)) as driver:
         async with driver.session(database="neo4j") as session:
             # Create indexes and constraints
             await create_indexes_and_constraints(session)

--- a/dbs/neo4j/scripts/build_graph.py
+++ b/dbs/neo4j/scripts/build_graph.py
@@ -125,7 +125,9 @@ async def build_query(tx: AsyncManagedTransaction, data: list[JsonBlob]) -> None
 
 
 async def main(files: list[str]) -> None:
-    async with AsyncGraphDatabase.driver(URI, auth=(NEO4J_USER, NEO4J_PASSWORD)) as driver:
+    async with AsyncGraphDatabase.driver(
+        URI, auth=(NEO4J_USER, NEO4J_PASSWORD)
+    ) as driver:
         async with driver.session(database="neo4j") as session:
             # Create indexes and constraints
             await create_indexes_and_constraints(session)


### PR DESCRIPTION
## Updates

* Set the docker container tag as the API version for simplicity (every time the FastAPI container tag changes, the API version in the docs follow suit with the same number)
* Fixed issues with type hints in API routers
  * Neo4j queries return vanilla dicts, and for some reason, FastAPI + Pydantic don't parse these prior to sending them as a response (this isn't an issue in Elastic)
* Updated README example cURL request and docs
* Fixed linting issues