### PR TITLE
Fix order of steps in setting up environment

### DIFF
--- a/dbs/meilisearch/README.md
+++ b/dbs/meilisearch/README.md
@@ -16,10 +16,12 @@ Note that this code base has been tested in Python 3.11, and requires a minimum 
 ```sh
 # Setup the environment for the first time
 python -m venv meili_venv  # python -> python 3.10+
-python -m pip install -r requirements.txt
 
 # Activate the environment (for subsequent runs)
 source meili_venv/bin/activate
+
+python -m pip install -r requirements.txt
+
 ```
 
 --- 


### PR DESCRIPTION
The README say to install the requirements and then activate the virtual environment. The will install the requirements as global packages rather than into the virtual environment so I switched the order of these steps to install to the virtual environment instead.