### PR TITLE
Update Meilisearch version and docker files

### DIFF
--- a/dbs/meilisearch/.env.example
+++ b/dbs/meilisearch/.env.example
@@ -1,6 +1,6 @@
 # Master key must be at least 16 bytes, composed of valid UTF-8 characters
 MEILI_MASTER_KEY = ""
-MEILI_VERSION = "v1.1"
+MEILI_VERSION = "v1.1.1"
 MEILI_PORT = 7700
 MEILI_URL = "localhost"
 MEILI_SERVICE = "meilisearch"

--- a/dbs/meilisearch/docker-compose.yml
+++ b/dbs/meilisearch/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     ports:
       - ${MEILI_PORT:-7700}:7700
     volumes:
-      - ./meili_data:/meili_data
+      - meili_data:/meili_data
     networks:
       - wine
   

--- a/dbs/meilisearch/requirements.txt
+++ b/dbs/meilisearch/requirements.txt
@@ -1,4 +1,4 @@
-meilisearch-python-async>=1.1.0
+meilisearch-python-async>=1.2.0
 pydantic>=1.10.7, <2.0.0
 fastapi>=0.95.0, <1.0.0
 httpx>=0.24.0

--- a/dbs/meilisearch/scripts/bulk_index.py
+++ b/dbs/meilisearch/scripts/bulk_index.py
@@ -167,6 +167,7 @@ async def main(files: list[str]) -> None:
             data = read_jsonl_from_file(file)
             data = validate(data, Wine, exclude_none=True)
             tasks.append(do_indexing(index, data, file))
+            print(f"Validated data from {Path(file).name} in pydantic")
         try:
             # Set id as primary key prior to indexing
             await asyncio.gather(*tasks)


### PR DESCRIPTION
## Updates

*  Bugfix: Mentioning the minor version of Meilisearch is important, as the docker resolver looks for this when starting the DB
   * Specifying the version as `v1.1.1` works as intended
* Improve comments and verify that timing performance results from #12 worked as intended  