### PR TITLE
Fix order of steps in virtual env in docs

### DIFF
--- a/dbs/elasticsearch/README.md
+++ b/dbs/elasticsearch/README.md
@@ -16,10 +16,11 @@ Note that this code base has been tested in Python 3.11, and requires a minimum 
 ```sh
 # Setup the environment for the first time
 python -m venv elastic_venv  # python -> python 3.10+
-python -m pip install -r requirements.txt
 
 # Activate the environment (for subsequent runs)
 source elastic_venv/bin/activate
+
+python -m pip install -r requirements.txt
 ```
 
 --- 

--- a/dbs/neo4j/README.md
+++ b/dbs/neo4j/README.md
@@ -19,9 +19,11 @@ Note that this code base has been tested in Python 3.11, and requires a minimum 
 ```sh
 # Setup the environment for the first time
 python -m venv neo4j_venv  # python -> python 3.10+
-python -m pip install -r requirements.txt
+
 # Activate the environment (for subsequent runs)
 source neoj_venv/bin/activate
+
+python -m pip install -r requirements.txt
 ```
 
 --- 


### PR DESCRIPTION
* The virtual environment should be activated  *before* performing the `pip install`