### PR TITLE
Meilisearch multi-process

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -29,4 +29,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           black: true
+          black_args: -l 100
           auto_fix: true

--- a/data/convert.py
+++ b/data/convert.py
@@ -13,9 +13,7 @@ def read_data(filename: str) -> list[JsonBlob]:
     return data
 
 
-def chunk_iterable(
-    item_list: list[JsonBlob], chunksize: int
-) -> Iterator[tuple[JsonBlob, ...]]:
+def chunk_iterable(item_list: list[JsonBlob], chunksize: int) -> Iterator[tuple[JsonBlob, ...]]:
     """
     Break a large iterable into an iterable of smaller iterables of size `chunksize`
     """
@@ -23,9 +21,7 @@ def chunk_iterable(
         yield tuple(item_list[i : i + chunksize])
 
 
-def write_chunked_data(
-    item_list: list[JsonBlob], output_name: str, chunksize: int = 5000
-) -> None:
+def write_chunked_data(item_list: list[JsonBlob], output_name: str, chunksize: int = 5000) -> None:
     """
     Write data to a zip file in chunks so that we don't dump all data into a single huge JSON file
     """

--- a/dbs/elasticsearch/api/routers/wine.py
+++ b/dbs/elasticsearch/api/routers/wine.py
@@ -19,9 +19,7 @@ wine_router = APIRouter()
 )
 async def search_by_keywords(
     request: Request,
-    terms: str = Query(
-        description="Search wine by keywords in title, description and variety"
-    ),
+    terms: str = Query(description="Search wine by keywords in title, description and variety"),
     max_price: int = Query(
         default=10000.0, description="Specify the maximum price for the wine (e.g., 30)"
     ),

--- a/dbs/elasticsearch/scripts/bulk_index.py
+++ b/dbs/elasticsearch/scripts/bulk_index.py
@@ -108,9 +108,7 @@ async def create_index(mappings_path: Path, client: AsyncElasticsearch) -> None:
         settings = config.get("settings")
         index_name = f"{INDEX_ALIAS}-1"
         try:
-            await client.indices.create(
-                index=index_name, mappings=mappings, settings=settings
-            )
+            await client.indices.create(index=index_name, mappings=mappings, settings=settings)
             await client.indices.put_alias(index=index_name, name=INDEX_ALIAS)
             # Verify that the new index has been created
             assert await client.indices.exists(index=index_name)
@@ -149,9 +147,7 @@ async def main(files: list[str]) -> None:
             data = read_jsonl_from_file(file)
             validated_data = validate(data, Wine)
             try:
-                await bulk_index_wines_to_elastic(
-                    elastic_client, INDEX_ALIAS, validated_data
-                )
+                await bulk_index_wines_to_elastic(elastic_client, INDEX_ALIAS, validated_data)
                 print(f"Indexed {Path(file).name} to db")
             except Exception as e:
                 print(f"{e}: Failed to index {Path(file).name} to db")
@@ -161,9 +157,7 @@ async def main(files: list[str]) -> None:
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        "Bulk index database from the wine reviews JSONL data"
-    )
+    parser = argparse.ArgumentParser("Bulk index database from the wine reviews JSONL data")
     parser.add_argument(
         "--limit",
         type=int,

--- a/dbs/meilisearch/api/routers/wine.py
+++ b/dbs/meilisearch/api/routers/wine.py
@@ -19,9 +19,7 @@ wine_router = APIRouter()
 )
 async def search_by_keywords(
     request: Request,
-    terms: str = Query(
-        description="Search wine by keywords in title, description and variety"
-    ),
+    terms: str = Query(description="Search wine by keywords in title, description and variety"),
     max_price: int = Query(
         default=10000.0, description="Specify the maximum price for the wine (e.g., 30)"
     ),

--- a/dbs/meilisearch/requirements.txt
+++ b/dbs/meilisearch/requirements.txt
@@ -1,4 +1,4 @@
-meilisearch-python-async>=1.2.0
+meilisearch-python-async==1.2.0
 pydantic>=1.10.7, <2.0.0
 fastapi>=0.95.0, <1.0.0
 httpx>=0.24.0

--- a/dbs/meilisearch/scripts/bulk_index.py
+++ b/dbs/meilisearch/scripts/bulk_index.py
@@ -187,9 +187,7 @@ async def main(files: list[str]) -> None:
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        "Bulk index database from the wine reviews JSONL data"
-    )
+    parser = argparse.ArgumentParser("Bulk index database from the wine reviews JSONL data")
     parser.add_argument(
         "--limit",
         type=int,

--- a/dbs/meilisearch/scripts/bulk_index.py
+++ b/dbs/meilisearch/scripts/bulk_index.py
@@ -4,11 +4,11 @@ import argparse
 import asyncio
 import glob
 import json
-from concurrent.futures import ProcessPoolExecutor
-from functools import lru_cache, partial
 import os
 import sys
 import zipfile
+from concurrent.futures import ProcessPoolExecutor
+from functools import lru_cache, partial
 from pathlib import Path
 from typing import Any
 

--- a/dbs/neo4j/scripts/build_graph.py
+++ b/dbs/neo4j/scripts/build_graph.py
@@ -125,9 +125,7 @@ async def build_query(tx: AsyncManagedTransaction, data: list[JsonBlob]) -> None
 
 
 async def main(files: list[str]) -> None:
-    async with AsyncGraphDatabase.driver(
-        URI, auth=(NEO4J_USER, NEO4J_PASSWORD)
-    ) as driver:
+    async with AsyncGraphDatabase.driver(URI, auth=(NEO4J_USER, NEO4J_PASSWORD)) as driver:
         async with driver.session(database="neo4j") as session:
             # Create indexes and constraints
             await create_indexes_and_constraints(session)


### PR DESCRIPTION
It's possible to further speed up the Meilisearch bulk indexing pipeline by processing the files on a concurrent process pool, and then running that inside an async event loop. (See  #15 for details).