### PR TITLE
Forward custom ports for FastAPI

### DIFF
--- a/dbs/elasticsearch/.env.example
+++ b/dbs/elasticsearch/.env.example
@@ -7,6 +7,7 @@ ELASTIC_PORT = 9200
 KIBANA_PORT = 5601
 ELASTIC_URL = "localhost"
 ELASTIC_SERVICE = "elasticsearch"
+API_PORT = 8002
 
 # Container image tag
 TAG = "0.1.0"

--- a/dbs/elasticsearch/docker-compose.yml
+++ b/dbs/elasticsearch/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     env_file:
       - .env
     ports:
-      - 8000:8000
+      - ${API_PORT}:8000
     depends_on:
       - elasticsearch
     volumes:

--- a/dbs/meilisearch/.env.example
+++ b/dbs/meilisearch/.env.example
@@ -4,6 +4,7 @@ MEILI_VERSION = "v1.1.1"
 MEILI_PORT = 7700
 MEILI_URL = "localhost"
 MEILI_SERVICE = "meilisearch"
+API_PORT = 8003
 
 # Container image tag
 TAG = "0.1.0"

--- a/dbs/meilisearch/docker-compose.yml
+++ b/dbs/meilisearch/docker-compose.yml
@@ -24,14 +24,14 @@ services:
     env_file:
       - .env
     ports:
-      - 8003:8003
+      - ${API_PORT}:8000
     depends_on:
       - meilisearch
     volumes:
       - ./:/wine
     networks:
       - wine
-    command: uvicorn api.main:app --host 0.0.0.0 --port 8003 --reload
+    command: uvicorn api.main:app --host 0.0.0.0 --port 8000 --reload
 
 volumes:
   meili_data:

--- a/dbs/neo4j/.env.example
+++ b/dbs/neo4j/.env.example
@@ -2,6 +2,7 @@
 NEO4J_PASSWORD = ""
 NEO4J_VERSION = 5.6.0
 DB_SERVICE = "db"
+API_PORT = 8001
 
 # Container image tag
 TAG = "0.2.0"

--- a/dbs/neo4j/docker-compose.yml
+++ b/dbs/neo4j/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     env_file:
       - .env
     ports:
-      - 8000:8000
+      - ${API_PORT}:8000
     depends_on:
       - db
     volumes:


### PR DESCRIPTION
When running tests between different DBs on the same machine, it can be useful to specify a custom port to forward the FastAPI connection to. This is now set in the `.env` files and the forwarding is done by parameter in the docker compose file.