### PR TITLE
Reorg and renaming

### DIFF
--- a/dbs/elasticsearch/api/main.py
+++ b/dbs/elasticsearch/api/main.py
@@ -7,7 +7,7 @@ from elasticsearch import AsyncElasticsearch
 from fastapi import FastAPI
 
 from api.config import Settings
-from api.routers.wine import wine_router
+from api.routers import rest
 
 
 @lru_cache()
@@ -60,4 +60,4 @@ async def root():
 
 
 # Attach routes
-app.include_router(wine_router, prefix="/wine", tags=["wine"])
+app.include_router(rest.router, prefix="/wine", tags=["wine"])

--- a/dbs/elasticsearch/api/routers/rest.py
+++ b/dbs/elasticsearch/api/routers/rest.py
@@ -7,13 +7,13 @@ from schemas.retriever import (
     TopWinesByProvince,
 )
 
-wine_router = APIRouter()
+router = APIRouter()
 
 
 # --- Routes ---
 
 
-@wine_router.get(
+@router.get(
     "/search",
     response_model=list[FullTextSearch],
     response_description="Search wines by title, description and variety",
@@ -22,7 +22,7 @@ async def search_by_keywords(
     request: Request,
     terms: str = Query(description="Search wine by keywords in title, description and variety"),
     max_price: int = Query(
-        default=10000.0, description="Specify the maximum price for the wine (e.g., 30)"
+        default=100.0, description="Specify the maximum price for the wine (e.g., 30)"
     ),
 ) -> list[FullTextSearch] | None:
     result = await _search_by_keywords(request.app.client, terms, max_price)
@@ -34,7 +34,7 @@ async def search_by_keywords(
     return result
 
 
-@wine_router.get(
+@router.get(
     "/top_by_country",
     response_model=list[TopWinesByCountry],
     response_description="Get top-rated wines by country",
@@ -54,7 +54,7 @@ async def top_by_country(
     return result
 
 
-@wine_router.get(
+@router.get(
     "/top_by_province",
     response_model=list[TopWinesByProvince],
     response_description="Get top-rated wines by province",
@@ -74,7 +74,7 @@ async def top_by_province(
     return result
 
 
-@wine_router.get(
+@router.get(
     "/count_by_country",
     response_model=CountByCountry,
     response_description="Get counts of wine for a particular country",
@@ -92,7 +92,7 @@ async def count_by_country(
     return result
 
 
-@wine_router.get(
+@router.get(
     "/count_by_filters",
     response_model=CountByCountry,
     response_description="Get counts of wine for a particular country, filtered by points and price",

--- a/dbs/meilisearch/api/main.py
+++ b/dbs/meilisearch/api/main.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI
 from meilisearch_python_async import Client
 
 from api.config import Settings
-from api.routers.wine import wine_router
+from api.routers import rest
 
 
 @lru_cache()
@@ -56,4 +56,4 @@ async def root():
 
 
 # Attach routes
-app.include_router(wine_router, prefix="/wine", tags=["wine"])
+app.include_router(rest.router, prefix="/wine", tags=["wine"])

--- a/dbs/meilisearch/api/routers/rest.py
+++ b/dbs/meilisearch/api/routers/rest.py
@@ -6,13 +6,13 @@ from schemas.retriever import (
     TopWinesByProvince,
 )
 
-wine_router = APIRouter()
+router = APIRouter()
 
 
 # --- Routes ---
 
 
-@wine_router.get(
+@router.get(
     "/search",
     response_model=list[FullTextSearch],
     response_description="Search wines by title, description and variety",
@@ -21,7 +21,7 @@ async def search_by_keywords(
     request: Request,
     terms: str = Query(description="Search wine by keywords in title, description and variety"),
     max_price: int = Query(
-        default=10000.0, description="Specify the maximum price for the wine (e.g., 30)"
+        default=100.0, description="Specify the maximum price for the wine (e.g., 30)"
     ),
 ) -> list[FullTextSearch] | None:
     result = await _search_by_keywords(request.app.client, terms, max_price)
@@ -33,7 +33,7 @@ async def search_by_keywords(
     return result
 
 
-@wine_router.get(
+@router.get(
     "/top_by_country",
     response_model=list[TopWinesByCountry],
     response_description="Get top-rated wines by country",
@@ -53,7 +53,7 @@ async def top_by_country(
     return result
 
 
-@wine_router.get(
+@router.get(
     "/top_by_province",
     response_model=list[TopWinesByProvince],
     response_description="Get top-rated wines by province",

--- a/dbs/neo4j/api/main.py
+++ b/dbs/neo4j/api/main.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI
 from neo4j import AsyncGraphDatabase
 
 from api.config import Settings
-from api.routers.wine import wine_router
+from api.routers import rest
 
 
 @lru_cache()
@@ -48,4 +48,4 @@ async def root():
 
 
 # Attach routes
-app.include_router(wine_router, prefix="/wine", tags=["wine"])
+app.include_router(rest.router, prefix="/wine", tags=["wine"])

--- a/dbs/neo4j/api/routers/rest.py
+++ b/dbs/neo4j/api/routers/rest.py
@@ -7,13 +7,13 @@ from schemas.retriever import (
     TopWinesByProvince,
 )
 
-wine_router = APIRouter()
+router = APIRouter()
 
 
 # --- Routes ---
 
 
-@wine_router.get(
+@router.get(
     "/search",
     response_model=list[FullTextSearch],
     response_description="Search wines by title and description",
@@ -22,7 +22,7 @@ async def search_by_keywords(
     request: Request,
     terms: str = Query(description="Search wine by keywords in title or description"),
     max_price: float = Query(
-        default=10000.0, description="Specify the maximum price for the wine (e.g., 30)"
+        default=100.0, description="Specify the maximum price for the wine (e.g., 30)"
     ),
 ) -> list[FullTextSearch] | None:
     session = request.app.session
@@ -35,7 +35,7 @@ async def search_by_keywords(
     return result
 
 
-@wine_router.get(
+@router.get(
     "/top_by_country",
     response_model=list[TopWinesByCountry],
     response_description="Get top-rated wines by country",
@@ -56,7 +56,7 @@ async def top_by_country(
     return result
 
 
-@wine_router.get(
+@router.get(
     "/top_by_province",
     response_model=list[TopWinesByProvince],
     response_description="Get top-rated wines by province",
@@ -77,7 +77,7 @@ async def top_by_province(
     return result
 
 
-@wine_router.get(
+@router.get(
     "/most_by_variety",
     response_model=list[MostWinesByVariety],
     response_description="Get the countries with the most wines above a points-rating of a specified variety (blended or otherwise)",

--- a/dbs/qdrant/api/main.py
+++ b/dbs/qdrant/api/main.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI
 from qdrant_client import QdrantClient
 
 from api.config import Settings
-from api.routers.wine import wine_router
+from api.routers import rest
 
 try:
     from optimum.onnxruntime import ORTModelForCustomTasks
@@ -75,4 +75,4 @@ async def root():
 
 
 # Attach routes
-app.include_router(wine_router, prefix="/wine", tags=["wine"])
+app.include_router(rest.router, prefix="/wine", tags=["wine"])

--- a/dbs/qdrant/api/routers/rest.py
+++ b/dbs/qdrant/api/routers/rest.py
@@ -3,13 +3,13 @@ from qdrant_client.http import models
 
 from schemas.retriever import CountByCountry, SimilaritySearch
 
-wine_router = APIRouter()
+router = APIRouter()
 
 
 # --- Routes ---
 
 
-@wine_router.get(
+@router.get(
     "/search",
     response_model=list[SimilaritySearch],
     response_description="Search for wines via semantically similar terms",
@@ -30,7 +30,7 @@ def search_by_similarity(
     return result
 
 
-@wine_router.get(
+@router.get(
     "/search_by_country",
     response_model=list[SimilaritySearch],
     response_description="Search for wines via semantically similar terms from a particular country",
@@ -52,7 +52,7 @@ def search_by_similarity_and_country(
     return result
 
 
-@wine_router.get(
+@router.get(
     "/search_by_filters",
     response_model=list[SimilaritySearch],
     response_description="Search for wines via semantically similar terms with added filters",
@@ -76,7 +76,7 @@ def search_by_similarity_and_filters(
     return result
 
 
-@wine_router.get(
+@router.get(
     "/count_by_country",
     response_model=CountByCountry,
     response_description="Get counts of wine for a particular country",
@@ -95,7 +95,7 @@ def count_by_country(
     return result
 
 
-@wine_router.get(
+@router.get(
     "/count_by_filters",
     response_model=CountByCountry,
     response_description="Get counts of wine for a particular country, filtered by points and price",

--- a/dbs/weaviate/api/main.py
+++ b/dbs/weaviate/api/main.py
@@ -6,7 +6,7 @@ import weaviate
 from fastapi import FastAPI
 
 from api.config import Settings
-from api.routers.wine import wine_router
+from api.routers import rest
 
 try:
     from optimum.onnxruntime import ORTModelForCustomTasks
@@ -77,4 +77,4 @@ async def root():
 
 
 # Attach routes
-app.include_router(wine_router, prefix="/wine", tags=["wine"])
+app.include_router(rest.router, prefix="/wine", tags=["wine"])

--- a/dbs/weaviate/api/routers/rest.py
+++ b/dbs/weaviate/api/routers/rest.py
@@ -1,13 +1,13 @@
 from fastapi import APIRouter, HTTPException, Query, Request
 from schemas.retriever import CountByCountry, SimilaritySearch
 
-wine_router = APIRouter()
+router = APIRouter()
 
 
 # --- Routes ---
 
 
-@wine_router.get(
+@router.get(
     "/search",
     response_model=list[SimilaritySearch],
     response_description="Search for wines via semantically similar terms",
@@ -28,7 +28,7 @@ def search_by_similarity(
     return result
 
 
-@wine_router.get(
+@router.get(
     "/search_by_country",
     response_model=list[SimilaritySearch],
     response_description="Search for wines via semantically similar terms from a particular country",
@@ -50,7 +50,7 @@ def search_by_similarity_and_country(
     return result
 
 
-@wine_router.get(
+@router.get(
     "/search_by_filters",
     response_model=list[SimilaritySearch],
     response_description="Search for wines via semantically similar terms with added filters",
@@ -74,7 +74,7 @@ def search_by_similarity_and_filters(
     return result
 
 
-@wine_router.get(
+@router.get(
     "/count_by_country",
     response_model=CountByCountry,
     response_description="Get counts of wine for a particular country",
@@ -93,7 +93,7 @@ def count_by_country(
     return result
 
 
-@wine_router.get(
+@router.get(
     "/count_by_filters",
     response_model=CountByCountry,
     response_description="Get counts of wine for a particular country, filtered by points and price",


### PR DESCRIPTION
## Updates

* It's easier to keep the name of the routers as `router` in all the files that we add new routes in
* We can just import `from api.routers import xxxx` in `main.py` within the FastAPI app and just call the router from that file as `xxxx.router` instead
* Reduced default value of `max_price` to 100 from 10000
* Renamed `wine.py` to just say `rest.py` as  this is a RESTful API