### PR TITLE
Pydantic v2 updates for Neo4j

### DIFF
--- a/dbs/neo4j/api/config.py
+++ b/dbs/neo4j/api/config.py
@@ -1,12 +1,15 @@
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        extra="allow",
+    )
+
     neo4j_service: str
     neo4j_url: str
     neo4j_user: str
     neo4j_password: str
     tag: str
 
-    class Config:
-        env_file = ".env"

--- a/dbs/neo4j/api/config.py
+++ b/dbs/neo4j/api/config.py
@@ -12,4 +12,3 @@ class Settings(BaseSettings):
     neo4j_user: str
     neo4j_password: str
     tag: str
-

--- a/dbs/neo4j/api/routers/rest.py
+++ b/dbs/neo4j/api/routers/rest.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, HTTPException, Query, Request
 from neo4j import AsyncManagedTransaction
+
 from schemas.retriever import (
     FullTextSearch,
     MostWinesByVariety,

--- a/dbs/neo4j/requirements.txt
+++ b/dbs/neo4j/requirements.txt
@@ -1,6 +1,8 @@
-neo4j>=5.8.0
-pydantic[dotenv]>=1.10.7, <2.0.0
-fastapi>=0.95.0, <1.0.0
+neo4j~=5.9.0
+pydantic~=2.0.0
+pydantic-settings~=2.0.0
+python-dotenv>=1.0.0
+fastapi~=0.100.0
 httpx>=0.24.0
 aiohttp>=3.8.4
 uvloop>=0.17.0

--- a/dbs/neo4j/schemas/retriever.py
+++ b/dbs/neo4j/schemas/retriever.py
@@ -26,6 +26,7 @@ class FullTextSearch(BaseModel):
     variety: str | None
     winery: str | None
 
+
 class TopWinesByCountry(BaseModel):
     wineID: int
     country: str

--- a/dbs/neo4j/schemas/retriever.py
+++ b/dbs/neo4j/schemas/retriever.py
@@ -1,18 +1,9 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class FullTextSearch(BaseModel):
-    wineID: int
-    country: str
-    title: str
-    description: str | None
-    points: int
-    price: float | str
-    variety: str | None
-    winery: str | None
-
-    class Config:
-        schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "wineID": 3845,
                 "country": "Italy",
@@ -24,7 +15,16 @@ class FullTextSearch(BaseModel):
                 "winery": "Castellinuzza e Piuca",
             }
         }
+    )
 
+    wineID: int
+    country: str
+    title: str
+    description: str | None
+    points: int
+    price: float | str
+    variety: str | None
+    winery: str | None
 
 class TopWinesByCountry(BaseModel):
     wineID: int

--- a/dbs/neo4j/schemas/wine.py
+++ b/dbs/neo4j/schemas/wine.py
@@ -7,7 +7,7 @@ class Wine(BaseModel):
         validate_assignment=True,
         extra="allow",
         str_strip_whitespace=True,
-        json_schema_extra = {
+        json_schema_extra={
             "example": {
                 "id": 45100,
                 "points": 85,
@@ -24,7 +24,7 @@ class Wine(BaseModel):
                 "taster_name": "Michael Schachner",
                 "taster_twitter_handle": "@wineschach",
             }
-        }
+        },
     )
 
     id: int
@@ -57,17 +57,18 @@ if __name__ == "__main__":
         "points": 85,
         "title": "Balduzzi 2012 Reserva Merlot (Maule Valley)",
         "description": "Ripe in color and aromas, this chunky wine delivers heavy baked-berry and raisin aromas in front of a jammy, extracted palate. Raisin and cooked berry flavors finish plump, with earthy notes.",
-        "price": 10,   # Test if field is cast to float
+        "price": 10,  # Test if field is cast to float
         "variety": "Merlot",
         "winery": "Balduzzi",
-        "designation": "Reserva",   # Test if field is renamed
-        "country": "null",   # Test unknown country
-        "province": " Maule Valley ",   # Test if field is stripped
+        "designation": "Reserva",  # Test if field is renamed
+        "country": "null",  # Test unknown country
+        "province": " Maule Valley ",  # Test if field is stripped
         "region_1": "null",
         "region_2": "null",
         "taster_name": "Michael Schachner",
         "taster_twitter_handle": "@wineschach",
     }
     from pprint import pprint
+
     wine = Wine(**data)
     pprint(wine.model_dump())

--- a/dbs/neo4j/schemas/wine.py
+++ b/dbs/neo4j/schemas/wine.py
@@ -1,26 +1,13 @@
-from pydantic import BaseModel, root_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class Wine(BaseModel):
-    id: int
-    points: int
-    title: str
-    description: str | None
-    price: float | None
-    variety: str | None
-    winery: str | None
-    vineyard: str | None
-    country: str | None
-    province: str | None
-    region_1: str | None
-    region_2: str | None
-    taster_name: str | None
-    taster_twitter_handle: str | None
-
-    class Config:
-        allow_population_by_field_name = True
-        validate_assignment = True
-        schema_extra = {
+    model_config = ConfigDict(
+        populate_by_name=True,
+        validate_assignment=True,
+        extra="allow",
+        str_strip_whitespace=True,
+        json_schema_extra = {
             "example": {
                 "id": 45100,
                 "points": 85,
@@ -38,19 +25,49 @@ class Wine(BaseModel):
                 "taster_twitter_handle": "@wineschach",
             }
         }
+    )
 
-    @root_validator(pre=True)
-    def _get_vineyard(cls, values):
-        "Rename designation to vineyard"
-        vineyard = values.pop("designation", None)
-        if vineyard:
-            values["vineyard"] = vineyard.strip()
-        return values
+    id: int
+    points: int
+    title: str
+    description: str | None
+    price: float | None
+    variety: str | None
+    winery: str | None
+    vineyard: str | None = Field(..., alias="designation")
+    country: str | None
+    province: str | None
+    region_1: str | None
+    region_2: str | None
+    taster_name: str | None
+    taster_twitter_handle: str | None
 
-    @root_validator
+    @model_validator(mode="before")
     def _fill_country_unknowns(cls, values):
         "Fill in missing country values with 'Unknown', as we always want this field to be queryable"
         country = values.get("country")
-        if not country:
+        if country is None or country == "null":
             values["country"] = "Unknown"
         return values
+
+
+if __name__ == "__main__":
+    data = {
+        "id": 45100,
+        "points": 85,
+        "title": "Balduzzi 2012 Reserva Merlot (Maule Valley)",
+        "description": "Ripe in color and aromas, this chunky wine delivers heavy baked-berry and raisin aromas in front of a jammy, extracted palate. Raisin and cooked berry flavors finish plump, with earthy notes.",
+        "price": 10,   # Test if field is cast to float
+        "variety": "Merlot",
+        "winery": "Balduzzi",
+        "designation": "Reserva",   # Test if field is renamed
+        "country": "null",   # Test unknown country
+        "province": " Maule Valley ",   # Test if field is stripped
+        "region_1": "null",
+        "region_2": "null",
+        "taster_name": "Michael Schachner",
+        "taster_twitter_handle": "@wineschach",
+    }
+    from pprint import pprint
+    wine = Wine(**data)
+    pprint(wine.model_dump())


### PR DESCRIPTION
# Updates for Pydantic v2

This PR incorporates changes to each DB's API and ingestion routines to work with Pydantic v2. Because of the [~5x performance improvement](https://thedataquarry.com/posts/why-pydantic-v2-matters/) seen when using Pydantic v2, we don't need to focus on optimizing the bulk ingestion too much during the validation stage -- as a result, alongside syntactic and API changes for Pydantic, the portions of the code that use multiprocessing for validation are simplified (and not required, because multiprocessing involves its own overhead).