### PR TITLE
Pydantic v2 Meilisearch

### DIFF
--- a/dbs/meilisearch/.env.example
+++ b/dbs/meilisearch/.env.example
@@ -1,13 +1,13 @@
 # Master key must be at least 16 bytes, composed of valid UTF-8 characters
 MEILI_MASTER_KEY = ""
-MEILI_VERSION = "v1.1.1"
+MEILI_VERSION = "v1.2.0"
 MEILI_PORT = 7700
 MEILI_URL = "localhost"
 MEILI_SERVICE = "meilisearch"
 API_PORT = 8003
 
 # Container image tag
-TAG = "0.1.0"
+TAG = "0.2.0"
 
 # Docker project namespace (defaults to the current folder name if not set)
 COMPOSE_PROJECT_NAME = meili_wine

--- a/dbs/meilisearch/api/config.py
+++ b/dbs/meilisearch/api/config.py
@@ -1,12 +1,14 @@
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        extra="allow",
+    )
+
     meili_service: str
     meili_master_key: str
     meili_port: int
     meili_url: str
     tag: str
-
-    class Config:
-        env_file = ".env"

--- a/dbs/meilisearch/api/routers/rest.py
+++ b/dbs/meilisearch/api/routers/rest.py
@@ -1,5 +1,6 @@
-from meilisearch_python_async import Client
 from fastapi import APIRouter, HTTPException, Query, Request
+from meilisearch_python_async import Client
+
 from schemas.retriever import (
     FullTextSearch,
     TopWinesByCountry,

--- a/dbs/meilisearch/requirements.txt
+++ b/dbs/meilisearch/requirements.txt
@@ -1,6 +1,8 @@
-meilisearch-python-async==1.2.0
-pydantic[dotenv]>=1.10.7, <2.0.0
-fastapi>=0.95.0, <1.0.0
+meilisearch-python-async~=1.4.0
+pydantic~=2.0.0
+pydantic-settings~=2.0.0
+python-dotenv>=1.0.0
+fastapi~=0.100.0
 httpx>=0.24.0
 aiohttp>=3.8.4
 uvicorn>=0.21.0, <1.0.0

--- a/dbs/meilisearch/schemas/retriever.py
+++ b/dbs/meilisearch/schemas/retriever.py
@@ -1,18 +1,9 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class FullTextSearch(BaseModel):
-    id: int
-    country: str
-    title: str
-    description: str | None
-    points: int
-    price: float | str | None
-    variety: str | None
-    winery: str | None
-
-    class Config:
-        schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "id": 3845,
                 "country": "Italy",
@@ -24,9 +15,23 @@ class FullTextSearch(BaseModel):
                 "winery": "Castellinuzza e Piuca",
             }
         }
+    )
+
+    id: int
+    country: str
+    title: str
+    description: str | None
+    points: int
+    price: float | str | None
+    variety: str | None
+    winery: str | None
 
 
 class TopWinesByCountry(BaseModel):
+    model_config = ConfigDict(
+        validate_assignment=True,
+    )
+
     id: int
     country: str
     title: str
@@ -36,11 +41,12 @@ class TopWinesByCountry(BaseModel):
     variety: str | None
     winery: str | None
 
-    class Config:
-        validate_assignment = True
-
 
 class TopWinesByProvince(BaseModel):
+    model_config = ConfigDict(
+        validate_assignment=True,
+    )
+
     id: int
     country: str
     province: str
@@ -50,6 +56,3 @@ class TopWinesByProvince(BaseModel):
     price: float | str | None = "Not available"
     variety: str | None
     winery: str | None
-
-    class Config:
-        validate_assignment = True

--- a/dbs/meilisearch/schemas/wine.py
+++ b/dbs/meilisearch/schemas/wine.py
@@ -1,26 +1,13 @@
-from pydantic import BaseModel, root_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class Wine(BaseModel):
-    id: int
-    points: int
-    title: str
-    description: str | None
-    price: float | None
-    variety: str | None
-    winery: str | None
-    vineyard: str | None
-    country: str | None
-    province: str | None
-    region_1: str | None
-    region_2: str | None
-    taster_name: str | None
-    taster_twitter_handle: str | None
-
-    class Config:
-        allow_population_by_field_name = True
-        validate_assignment = True
-        schema_extra = {
+    model_config = ConfigDict(
+        populate_by_name=True,
+        validate_assignment=True,
+        extra="allow",
+        str_strip_whitespace=True,
+        json_schema_extra={
             "example": {
                 "id": 45100,
                 "points": 85,
@@ -37,20 +24,51 @@ class Wine(BaseModel):
                 "taster_name": "Michael Schachner",
                 "taster_twitter_handle": "@wineschach",
             }
-        }
+        },
+    )
 
-    @root_validator(pre=True)
-    def _get_vineyard(cls, values):
-        "Rename designation to vineyard"
-        vineyard = values.pop("designation", None)
-        if vineyard:
-            values["vineyard"] = vineyard.strip()
-        return values
+    id: int
+    points: int
+    title: str
+    description: str | None
+    price: float | None
+    variety: str | None
+    winery: str | None
+    vineyard: str | None = Field(..., alias="designation")
+    country: str | None
+    province: str | None
+    region_1: str | None
+    region_2: str | None
+    taster_name: str | None
+    taster_twitter_handle: str | None
 
-    @root_validator
+    @model_validator(mode="before")
     def _fill_country_unknowns(cls, values):
         "Fill in missing country values with 'Unknown', as we always want this field to be queryable"
         country = values.get("country")
-        if not country:
+        if country is None or country == "null":
             values["country"] = "Unknown"
         return values
+
+
+if __name__ == "__main__":
+    data = {
+        "id": 45100,
+        "points": 85,
+        "title": "Balduzzi 2012 Reserva Merlot (Maule Valley)",
+        "description": "Ripe in color and aromas, this chunky wine delivers heavy baked-berry and raisin aromas in front of a jammy, extracted palate. Raisin and cooked berry flavors finish plump, with earthy notes.",
+        "price": 10,  # Test if field is cast to float
+        "variety": "Merlot",
+        "winery": "Balduzzi",
+        "designation": "Reserva",  # Test if field is renamed
+        "country": "null",  # Test unknown country
+        "province": " Maule Valley ",  # Test if field is stripped
+        "region_1": "null",
+        "region_2": "null",
+        "taster_name": "Michael Schachner",
+        "taster_twitter_handle": "@wineschach",
+    }
+    from pprint import pprint
+
+    wine = Wine(**data)
+    pprint(wine.model_dump(), sort_dicts=False)

--- a/dbs/meilisearch/scripts/bulk_index.py
+++ b/dbs/meilisearch/scripts/bulk_index.py
@@ -14,7 +14,6 @@ from dotenv import load_dotenv
 from meilisearch_python_async import Client
 from meilisearch_python_async.index import Index
 from meilisearch_python_async.models.settings import MeilisearchSettings
-from pydantic.main import ModelMetaclass
 
 sys.path.insert(1, os.path.realpath(Path(__file__).resolve().parents[1]))
 from api.config import Settings
@@ -62,15 +61,16 @@ def get_json_data(data_dir: Path, filename: str) -> list[JsonBlob]:
 
 def validate(
     data: list[JsonBlob],
-    model: ModelMetaclass,
     exclude_none: bool = False,
 ) -> list[JsonBlob]:
-    validated_data = [model(**item).dict(exclude_none=exclude_none) for item in data]
+    validated_data = [
+        Wine(**item).model_dump(exclude_none=exclude_none) for item in data
+    ]
     return validated_data
 
 
 def process_chunks(data: list[JsonBlob]) -> tuple[list[JsonBlob], str]:
-    validated_data = validate(data, Wine, exclude_none=True)
+    validated_data = validate(data, exclude_none=True)
     return validated_data
 
 

--- a/dbs/meilisearch/scripts/bulk_index.py
+++ b/dbs/meilisearch/scripts/bulk_index.py
@@ -63,9 +63,7 @@ def validate(
     data: list[JsonBlob],
     exclude_none: bool = False,
 ) -> list[JsonBlob]:
-    validated_data = [
-        Wine(**item).model_dump(exclude_none=exclude_none) for item in data
-    ]
+    validated_data = [Wine(**item).model_dump(exclude_none=exclude_none) for item in data]
     return validated_data
 
 


### PR DESCRIPTION
Fixes #31.

## Updates

Fixes that updates Meilisearch section to use Pydantic v2. Performance is GREAT (Timing numbers on M2 macOS shown below).

- No changes required to the `meilisearch-python-async` code from the prior version (using latest [meilisearch-python-async](https://github.com/sanders41/meilisearch-python-async) version `1.4.5` as of today)
- Minor changes to validator and config logic in Pydantic schemas
- Impact on run time with Pydantic is small, mainly because most of the overhead in `bulk_index.py` script is due to firing up multiple processes via `concurrent.futures.ProcessPoolExecutor`

Earlier version using Pydantic v1 ran in ~3.3 seconds, the new version with Pydantic v2 runs in ~2.7 seconds.

```sj
$ time python bulk_index.py
Finished updating database index settings
Processing chunks
Processed ids in range 1-10000
Processed ids in range 20001-30000
Processed ids in range 60001-70000
Processed ids in range 50001-60000
Processed ids in range 10001-20000
Processed ids in range 100001-110000
Processed ids in range 80001-90000
Processed ids in range 70001-80000
Processed ids in range 40001-50000
Processed ids in range 120001-129971
Processed ids in range 30001-40000
Processed ids in range 110001-120000
Processed ids in range 90001-100000
Finished execution!
python bulk_index.py  4.97s user 0.77s system 206% cpu 2.783 total
```

Although the total run time reduction in this case was relatively small, in a larger dataset (with millions of records), the initial overhead of multiple CPU processes is totally worth it, as the async client will very efficiently process each batch with faster underlying validation logic (enabled by Pydantic v2).

## Rule of thumb

@sanders41, I think that for best performance for async loading, it makes sense to wrap the validation logic for the data within the multiprocess logic, as you originally suggested. That allows users to exploit the best of the underlying CPUs as well as the event loop that's handling many batches concurrently.