### PR TITLE
Bug fix: FastAPI response in Meilisearch

### DIFF
--- a/dbs/meilisearch/api/main.py
+++ b/dbs/meilisearch/api/main.py
@@ -29,6 +29,7 @@ async def get_search_api_key(settings) -> str:
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Search for wines by keyword phrase using Meilisearch
     settings = get_settings()
+    print(settings)
     search_key = await get_search_api_key(settings)
     URI = f"http://{settings.meili_service}:{settings.meili_port}"
     async with Client(URI, search_key) as client:

--- a/dbs/meilisearch/api/routers/rest.py
+++ b/dbs/meilisearch/api/routers/rest.py
@@ -103,6 +103,7 @@ async def _top_by_country(
         sort=["points:desc", "price:asc"],
     )
     if response:
+        print(response.hits)
         return response.hits
     return None
 

--- a/dbs/meilisearch/scripts/settings/settings.json
+++ b/dbs/meilisearch/scripts/settings/settings.json
@@ -26,10 +26,14 @@
         "variety"
     ],
     "displayedAttributes": [
+        "id",
+        "points",
+        "price",
         "title",
         "country",
         "province",
         "variety",
+        "winery",
         "taster_name",
         "description"
     ],


### PR DESCRIPTION
# FastAPI bug fix for Meilisearch

- Fields like id, price and points weren't marked in the displayed attributes
- As a result, queries to the endpoints were returning incomplete results that failed Pydantic validation
- All fields marked as "displayed" attributes in the Meilisearch JSON schema need to be in the Pydantic schema, and vice versa
- Tests should cover this pretty effectively, but it's important to know how to structure the Meilisearch schema in line with the FastAPI models that validate responses from user queries