### PR TITLE
Pydantic v2 Elasticsearch

### DIFF
--- a/dbs/elasticsearch/.env.example
+++ b/dbs/elasticsearch/.env.example
@@ -10,7 +10,7 @@ ELASTIC_SERVICE = "elasticsearch"
 API_PORT = 8002
 
 # Container image tag
-TAG = "0.1.0"
+TAG = "0.2.0"
 
 # Docker project namespace (defaults to the current folder name if not set)
 COMPOSE_PROJECT_NAME = elastic_wine

--- a/dbs/elasticsearch/api/config.py
+++ b/dbs/elasticsearch/api/config.py
@@ -1,7 +1,12 @@
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        extra="allow",
+    )
+
     elastic_service: str
     elastic_user: str
     elastic_password: str
@@ -10,5 +15,3 @@ class Settings(BaseSettings):
     elastic_index_alias: str
     tag: str
 
-    class Config:
-        env_file = ".env"

--- a/dbs/elasticsearch/api/config.py
+++ b/dbs/elasticsearch/api/config.py
@@ -14,4 +14,3 @@ class Settings(BaseSettings):
     elastic_port: int
     elastic_index_alias: str
     tag: str
-

--- a/dbs/elasticsearch/api/routers/rest.py
+++ b/dbs/elasticsearch/api/routers/rest.py
@@ -1,5 +1,6 @@
 from elasticsearch import AsyncElasticsearch
 from fastapi import APIRouter, HTTPException, Query, Request
+
 from schemas.retriever import (
     CountByCountry,
     FullTextSearch,

--- a/dbs/elasticsearch/requirements.txt
+++ b/dbs/elasticsearch/requirements.txt
@@ -1,6 +1,8 @@
-elasticsearch>=8.7.0
-pydantic[dotenv]>=1.10.7, <2.0.0
-fastapi>=0.95.0, <1.0.0
+elasticsearch~=8.7.0
+pydantic~=2.0.0
+pydantic-settings~=2.0.0
+python-dotenv>=1.0.0
+fastapi~=0.100.0
 httpx>=0.24.0
 aiohttp>=3.8.4
 uvicorn>=0.21.0, <1.0.0

--- a/dbs/elasticsearch/schemas/retriever.py
+++ b/dbs/elasticsearch/schemas/retriever.py
@@ -1,18 +1,9 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class FullTextSearch(BaseModel):
-    id: int
-    country: str
-    title: str
-    description: str | None
-    points: int
-    price: float | str | None
-    variety: str | None
-    winery: str | None
-
-    class Config:
-        schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "id": 3845,
                 "country": "Italy",
@@ -24,6 +15,16 @@ class FullTextSearch(BaseModel):
                 "winery": "Castellinuzza e Piuca",
             }
         }
+    )
+
+    id: int
+    country: str
+    title: str
+    description: str | None
+    points: int
+    price: float | str | None
+    variety: str | None
+    winery: str | None
 
 
 class TopWinesByCountry(BaseModel):
@@ -36,9 +37,6 @@ class TopWinesByCountry(BaseModel):
     variety: str | None
     winery: str | None
 
-    class Config:
-        validate_assignment = True
-
 
 class TopWinesByProvince(BaseModel):
     id: int
@@ -50,9 +48,6 @@ class TopWinesByProvince(BaseModel):
     price: float | str | None = "Not available"
     variety: str | None
     winery: str | None
-
-    class Config:
-        validate_assignment = True
 
 
 class MostWinesByVariety(BaseModel):

--- a/dbs/elasticsearch/schemas/wine.py
+++ b/dbs/elasticsearch/schemas/wine.py
@@ -57,7 +57,6 @@ class Wine(BaseModel):
         return values
 
 
-
 if __name__ == "__main__":
     data = {
         "id": 45100,

--- a/dbs/elasticsearch/schemas/wine.py
+++ b/dbs/elasticsearch/schemas/wine.py
@@ -1,26 +1,13 @@
-from pydantic import BaseModel, root_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class Wine(BaseModel):
-    id: int
-    points: int
-    title: str
-    description: str | None
-    price: float | None
-    variety: str | None
-    winery: str | None
-    vineyard: str | None
-    country: str | None
-    province: str | None
-    region_1: str | None
-    region_2: str | None
-    taster_name: str | None
-    taster_twitter_handle: str | None
-
-    class Config:
-        allow_population_by_field_name = True
-        validate_assignment = True
-        schema_extra = {
+    model_config = ConfigDict(
+        populate_by_name=True,
+        validate_assignment=True,
+        extra="allow",
+        str_strip_whitespace=True,
+        json_schema_extra={
             "example": {
                 "id": 45100,
                 "points": 85,
@@ -37,26 +24,58 @@ class Wine(BaseModel):
                 "taster_name": "Michael Schachner",
                 "taster_twitter_handle": "@wineschach",
             }
-        }
+        },
+    )
 
-    @root_validator
-    def _create_id_field(cls, values):
-        "Elastic needs an _id field to create unique documents, so we just use the existing id field"
-        values["_id"] = values["id"]
-        return values
+    id: int
+    points: int
+    title: str
+    description: str | None
+    price: float | None
+    variety: str | None
+    winery: str | None
+    vineyard: str | None = Field(..., alias="designation")
+    country: str | None
+    province: str | None
+    region_1: str | None
+    region_2: str | None
+    taster_name: str | None
+    taster_twitter_handle: str | None
 
-    @root_validator(pre=True)
-    def _get_vineyard(cls, values):
-        "Rename designation to vineyard"
-        vineyard = values.pop("designation", None)
-        if vineyard:
-            values["vineyard"] = vineyard.strip()
-        return values
-
-    @root_validator
+    @model_validator(mode="before")
     def _fill_country_unknowns(cls, values):
         "Fill in missing country values with 'Unknown', as we always want this field to be queryable"
         country = values.get("country")
-        if not country:
+        if country is None or country == "null":
             values["country"] = "Unknown"
         return values
+
+    @model_validator(mode="before")
+    def _create_id(cls, values):
+        "Create an _id field because Elastic needs this to store as primary key"
+        values["_id"] = values["id"]
+        return values
+
+
+
+if __name__ == "__main__":
+    data = {
+        "id": 45100,
+        "points": 85,
+        "title": "Balduzzi 2012 Reserva Merlot (Maule Valley)",
+        "description": "Ripe in color and aromas, this chunky wine delivers heavy baked-berry and raisin aromas in front of a jammy, extracted palate. Raisin and cooked berry flavors finish plump, with earthy notes.",
+        "price": 10,  # Test if field is cast to float
+        "variety": "Merlot",
+        "winery": "Balduzzi",
+        "designation": "Reserva",  # Test if field is renamed
+        "country": "null",  # Test unknown country
+        "province": " Maule Valley ",  # Test if field is stripped
+        "region_1": "null",
+        "region_2": "null",
+        "taster_name": "Michael Schachner",
+        "taster_twitter_handle": "@wineschach",
+    }
+    from pprint import pprint
+
+    wine = Wine(**data)
+    pprint(wine.model_dump(), sort_dicts=False)

--- a/dbs/elasticsearch/scripts/bulk_index.py
+++ b/dbs/elasticsearch/scripts/bulk_index.py
@@ -11,7 +11,6 @@ from typing import Any, Iterator
 import srsly
 from dotenv import load_dotenv
 from elasticsearch import AsyncElasticsearch, helpers
-from pydantic.main import ModelMetaclass
 
 sys.path.insert(1, os.path.realpath(Path(__file__).resolve().parents[1]))
 from api.config import Settings
@@ -59,15 +58,14 @@ def get_json_data(data_dir: Path, filename: str) -> list[JsonBlob]:
 
 def validate(
     data: tuple[JsonBlob],
-    model: ModelMetaclass,
     exclude_none: bool = False,
 ) -> list[JsonBlob]:
-    validated_data = [model(**item).dict(exclude_none=exclude_none) for item in data]
+    validated_data = [Wine(**item).dict(exclude_none=exclude_none) for item in data]
     return validated_data
 
 
 def process_chunks(data: list[JsonBlob]) -> tuple[list[JsonBlob], str]:
-    validated_data = validate(data, Wine, exclude_none=True)
+    validated_data = validate(data, exclude_none=True)
     return validated_data
 
 


### PR DESCRIPTION
## Updates

Updated Elasticsearch API to use Pydantic v2. In a similar way to Meilisearch, we are able to attach a running event loop to a multi-process pool of CPUs that can perform Pydantic validation and bulk indexing concurrently on multiple batches. The Elasticsearch async client allows us to efficiently do this in a non-blocking manner. The timing numbers on an M2 macbook pro are shown below.

```sh
$ cd dbs/elasticsearch/scripts
$ time python bulk_index.py
Found index wines in db, skipping index creation...

Processing chunks
Processed ids in range 1-10000
Processed ids in range 10001-20000
Processed ids in range 50001-60000
Processed ids in range 60001-70000
Processed ids in range 30001-40000
Processed ids in range 20001-30000
Processed ids in range 40001-50000
Processed ids in range 90001-100000
Processed ids in range 70001-80000
Processed ids in range 80001-90000
Processed ids in range 120001-129971
Processed ids in range 100001-110000
Processed ids in range 110001-120000
Finished execution!
python bulk_index.py  7.03s user 0.82s system 115% cpu 6.787 total
```